### PR TITLE
add getInitialNotification if notification unhandled caused app restarted.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ React Native SDK for [Pushdy](https://guide.pushdy.com/i/) services
   - [stopHandleIncommingNotification()](#stophandleincommingnotification)
   - [getPendingNotification()](#getpendingnotification)
   - [getPendingNotifications()](#getpendingnotifications)
+  - [getInitialNotification()](#getinitialnotification)
   - [setAttribute(attr: String, value)](#setattributeattr-string-value)
   - [pushAttribute(attr: String, value, commitImmediately: boolean)](#pushattributeattr-string-value-commitimmediately-boolean)
   - [getPlayerID()](#getplayerid)
@@ -628,6 +629,33 @@ const pendingNotification:PushdyNotification = await Pushdy.getPendingNotificati
 const pendingNotifications:PushdyNotification[] = await Pushdy.getPendingNotifications();
 ```
 
+##### getInitialNotification()
+Description: 
+> To retrigger lastest opened notification that has not handled yet. Call this function to re-trigger lastest opened notification.
+> Some case you might need this function:
+> * Your app need restart after some long delay in background. 
+> * User open from push but OS killed when app start.
+
+Usage:
+```
+const initialNotification = await Pushdy.getInitialNotification();
+//
+// handled notification action
+//
+// When you handled notification action call removeIntialNotification() to remove old notification to make sure that doesn't re-trigger handled notification in next-time app restarts.
+Pushdy.removeInitialNotification();
+```
+
+##### removeInitialNotification()
+Description: 
+- Remove handled notification inside openNotificationOpened
+- If you dont use getIntialNotification, don't bother this function.
+
+Usage:
+
+```
+Pushdy.removeInitialNotification();
+```
 
 ##### setAttribute(attr: String, value)
 Signature:

--- a/android/src/main/java/com/reactNativePushdy/PushdyModule.java
+++ b/android/src/main/java/com/reactNativePushdy/PushdyModule.java
@@ -162,6 +162,17 @@ public class PushdyModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public  void getInitialNotification(Promise promise) {
+        promise.resolve(pushdySdk.getInitialNotification());
+    }
+
+    @ReactMethod
+    public  void removeInitialNotification(Promise promise) {
+        pushdySdk.removeInitialNotification();
+        promise.resolve(true);
+    }
+
+    @ReactMethod
     public void setAttribute(String attr, Object value, Promise promise) {
         pushdySdk.setAttribute(attr, value);
         promise.resolve(true);

--- a/android/src/main/java/com/reactNativePushdy/PushdySdk.java
+++ b/android/src/main/java/com/reactNativePushdy/PushdySdk.java
@@ -302,18 +302,21 @@ public class PushdySdk implements Pushdy.PushdyDelegate {
    * If you handled initicalNotification successful, please call removeInitalNotification.
    * @return JSONObject
    */
-  public JSONObject getInitialNotification() {
-    JSONObject jo = new JSONObject();
+  public WritableMap getInitialNotification() {
+    WritableMap data = new WritableNativeMap();
+
     try {
       String initialNotification = PDYStorage.getString(reactContext, "initialNotification");
-      jo = new JSONObject(initialNotification);
+      JSONObject jo = new JSONObject(initialNotification);
+      data = ReactNativeJson.convertJsonToMap(jo);
     } catch (JSONException e) {
       e.printStackTrace();
-      Log.e("RNPushdy","getInitialNotification Exception" + e.getMessage());
+      Log.e("RNPushdy", "getPendingNotification Exception " + e.getMessage());
     }
-    return  jo;
-  }
 
+    return data;
+  }
+  
   public void removeInitialNotification() {
     PDYStorage.remove(mainAppContext, "initialNotification");
   }

--- a/android/src/main/java/com/reactNativePushdy/PushdySdk.java
+++ b/android/src/main/java/com/reactNativePushdy/PushdySdk.java
@@ -26,7 +26,6 @@ import java.util.Timer;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.Arguments;
-import com.pushdy.core.ultilities.PDYStorage;
 
 
 public class PushdySdk implements Pushdy.PushdyDelegate {
@@ -281,7 +280,7 @@ public class PushdySdk implements Pushdy.PushdyDelegate {
     try {
       JSONObject jo = new JSONObject(notification);
       noti = ReactNativeJson.convertJsonToMap(jo);
-      PDYStorage.setString(reactContext,"initialNotification", notification);
+      RNPushdyData.setString(reactContext, "initialNotification", notification);
     } catch (JSONException e) {
       e.printStackTrace();
       Log.e("RNPushdy", "onNotificationReceived Exception " + e.getMessage());
@@ -306,7 +305,7 @@ public class PushdySdk implements Pushdy.PushdyDelegate {
     WritableMap data = new WritableNativeMap();
 
     try {
-      String initialNotification = PDYStorage.getString(reactContext, "initialNotification");
+      String initialNotification = RNPushdyData.getString(reactContext, "initialNotification");
       if(initialNotification != null){
         JSONObject jo = new JSONObject(initialNotification);
         data = ReactNativeJson.convertJsonToMap(jo);
@@ -320,7 +319,7 @@ public class PushdySdk implements Pushdy.PushdyDelegate {
   }
 
   public void removeInitialNotification() {
-    PDYStorage.remove(reactContext, "initialNotification");
+    RNPushdyData.removeString(reactContext, "initialNotification");
   }
 
 

--- a/android/src/main/java/com/reactNativePushdy/PushdySdk.java
+++ b/android/src/main/java/com/reactNativePushdy/PushdySdk.java
@@ -301,7 +301,8 @@ public class PushdySdk implements Pushdy.PushdyDelegate {
    * notification is saved.
    * getInitialNotification is used to re-trigger open notification when app restarts.
    * If you handled initicalNotification successful, please call removeInitalNotification.
-   * @return JSONObject
+   * For more info: https://github.com/Pushdy/react-native-pushdy/issues/3
+   * @return WritableMap
    */
   public WritableMap getInitialNotification() {
     WritableMap data = new WritableNativeMap();

--- a/android/src/main/java/com/reactNativePushdy/PushdySdk.java
+++ b/android/src/main/java/com/reactNativePushdy/PushdySdk.java
@@ -26,6 +26,7 @@ import java.util.Timer;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.Arguments;
+import com.pushdy.core.ultilities.PDYStorage;
 
 
 public class PushdySdk implements Pushdy.PushdyDelegate {
@@ -285,12 +286,42 @@ public class PushdySdk implements Pushdy.PushdyDelegate {
       Log.e("RNPushdy", "onNotificationReceived Exception " + e.getMessage());
     }
 
+    /**
+     *
+     */
+
+    PDYStorage.setString(mainAppContext,"initialNotification", notification);
     WritableMap params = Arguments.createMap();
     params.putString("fromState", fromState);
     params.putMap("notification", RNPushdyData.toRNPushdyStructure(noti));
 
     sendEvent("onNotificationOpened", params);
   }
+
+  /**
+   * Flow here:
+   * When clicking notification from background or foreground. onNotificationOpened is triggered then
+   * notification is saved.
+   * getInitialNotification is used to re-trigger open notification when app restarts.
+   * If you handled initicalNotification successful, please call removeInitalNotification.
+   * @return JSONObject
+   */
+  public JSONObject getInitialNotification() {
+    JSONObject jo = new JSONObject();
+    try {
+      String initialNotification = PDYStorage.getString(mainAppContext, "initialNotification");
+      jo = new JSONObject(initialNotification);
+    } catch (JSONException e) {
+      e.printStackTrace();
+      Log.e("RNPushdy","getInitialNotification Exception" + e.getMessage());
+    }
+    return  jo;
+  }
+
+  public void removeInitialNotification() {
+    PDYStorage.remove(mainAppContext, "initialNotification");
+  }
+
 
   @Override
   public void onNotificationReceived(@NotNull String notification, @NotNull String fromState) {

--- a/android/src/main/java/com/reactNativePushdy/PushdySdk.java
+++ b/android/src/main/java/com/reactNativePushdy/PushdySdk.java
@@ -225,12 +225,14 @@ public class PushdySdk implements Pushdy.PushdyDelegate {
   Tried to support initPushdy SDK from JS whenever we want, without success.
   I stored the draft version here, to remind anyone who wanna init the SDK from JS,
   It's not possible at the moment, depend on PushdySDK and its working flow.
-
+  // the OLD flow is:
+  // 1. Init PushdySDK to do some required work (see the SDK)
+  // 2. Whenever you wanna start Pushdy (often on JS App mounting), call setDeviceId, Pushdy SDK will create a `Player` on the dashboard
+  // 3. From now on, PushdySDK is ready to work.
   Currently, the flow is:
-  1. Init PushdySDK to do some required work (see the SDK)
-  2. Whenever you wanna start Pushdy (often on JS App mounting), call setDeviceId, Pushdy SDK will create a `Player` on the dashboard
+  1. registerSdk to init native SDK and prepare
+  2. Whenever you wanna start Pushdy (often on JS App mounting), call initPushdy, Pushdy SDK will create a `Player` on the dashboard
   3. From now on, PushdySDK is ready to work.
-
 
   public void old_registerSdk(android.content.Context mainAppContext, Integer smallIcon) {
     this.mainAppContext = mainAppContext;

--- a/android/src/main/java/com/reactNativePushdy/PushdySdk.java
+++ b/android/src/main/java/com/reactNativePushdy/PushdySdk.java
@@ -307,8 +307,10 @@ public class PushdySdk implements Pushdy.PushdyDelegate {
 
     try {
       String initialNotification = PDYStorage.getString(reactContext, "initialNotification");
-      JSONObject jo = new JSONObject(initialNotification);
-      data = ReactNativeJson.convertJsonToMap(jo);
+      if(initialNotification != null){
+        JSONObject jo = new JSONObject(initialNotification);
+        data = ReactNativeJson.convertJsonToMap(jo);
+      }
     } catch (JSONException e) {
       e.printStackTrace();
       Log.e("RNPushdy", "getPendingNotification Exception " + e.getMessage());

--- a/android/src/main/java/com/reactNativePushdy/PushdySdk.java
+++ b/android/src/main/java/com/reactNativePushdy/PushdySdk.java
@@ -316,9 +316,9 @@ public class PushdySdk implements Pushdy.PushdyDelegate {
 
     return data;
   }
-  
+
   public void removeInitialNotification() {
-    PDYStorage.remove(mainAppContext, "initialNotification");
+    PDYStorage.remove(reactContext, "initialNotification");
   }
 
 

--- a/android/src/main/java/com/reactNativePushdy/PushdySdk.java
+++ b/android/src/main/java/com/reactNativePushdy/PushdySdk.java
@@ -281,16 +281,12 @@ public class PushdySdk implements Pushdy.PushdyDelegate {
     try {
       JSONObject jo = new JSONObject(notification);
       noti = ReactNativeJson.convertJsonToMap(jo);
+      PDYStorage.setString(reactContext,"initialNotification", notification);
     } catch (JSONException e) {
       e.printStackTrace();
       Log.e("RNPushdy", "onNotificationReceived Exception " + e.getMessage());
     }
 
-    /**
-     *
-     */
-
-    PDYStorage.setString(mainAppContext,"initialNotification", notification);
     WritableMap params = Arguments.createMap();
     params.putString("fromState", fromState);
     params.putMap("notification", RNPushdyData.toRNPushdyStructure(noti));
@@ -309,7 +305,7 @@ public class PushdySdk implements Pushdy.PushdyDelegate {
   public JSONObject getInitialNotification() {
     JSONObject jo = new JSONObject();
     try {
-      String initialNotification = PDYStorage.getString(mainAppContext, "initialNotification");
+      String initialNotification = PDYStorage.getString(reactContext, "initialNotification");
       jo = new JSONObject(initialNotification);
     } catch (JSONException e) {
       e.printStackTrace();

--- a/android/src/main/java/com/reactNativePushdy/RNPushdyData.java
+++ b/android/src/main/java/com/reactNativePushdy/RNPushdyData.java
@@ -1,5 +1,7 @@
 package com.reactNativePushdy;
 
+import android.content.Context;
+
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
@@ -197,5 +199,18 @@ public class RNPushdyData {
     }
 
     return out;
+  }
+
+  static void setString(Context context, String key, String value) {
+    context.getSharedPreferences("PushdyStorageRef", Context.MODE_PRIVATE).edit().putString(key, value).commit();
+  }
+
+  static String getString(Context context, String key) {
+
+    return context.getSharedPreferences("PushdyStorageRef", Context.MODE_PRIVATE).getString(key, null);
+  }
+
+  static  void removeString(Context context, String key) {
+    context.getSharedPreferences("PushdyStorageRef", Context.MODE_PRIVATE).edit().remove(key).commit();
   }
 }

--- a/index.js
+++ b/index.js
@@ -342,6 +342,7 @@ class RNPushdyWrapper {
    * notification is saved.
    * getInitialNotification is used to re-trigger open notification when app restarts.
    * If you handled initicalNotification successful, please call removeInitalNotification.
+   * Resolved issue: https://github.com/Pushdy/react-native-pushdy/issues/3
    * @return JSONObject
    */
   async getInitialNotification() {

--- a/index.js
+++ b/index.js
@@ -23,9 +23,9 @@ if (__DEV__) {
       console.log('%c' + fromTo + ' args, msg:', 'color: ' + color, msg.args, msg)
     }
   })
-  console.log('{PushdyMessaging} Spy enabled: ', );
+  console.log('{PushdyMessaging} Spy enabled: ',);
 } else {
-  console.log('{PushdyMessaging} Spy disabled: ', );
+  console.log('{PushdyMessaging} Spy disabled: ',);
 }
 
 const { RNPushdy } = NativeModules;
@@ -336,6 +336,23 @@ class RNPushdyWrapper {
     return items.map(i => new PushdyNotification(i));
   }
 
+  /**
+   * Flow here:
+   * When clicking notification from background or foreground. onNotificationOpened is triggered then
+   * notification is saved.
+   * getInitialNotification is used to re-trigger open notification when app restarts.
+   * If you handled initicalNotification successful, please call removeInitalNotification.
+   * @return JSONObject
+   */
+  async getInitialNotification() {
+    let initialNotification = await this.callNative(RNPushdy.getInitialNotification)
+    return initialNotification;
+  }
+
+  async removeInitialNotification() {
+    return this.callNative(RNPushdy.removeInitialNotification);
+  }
+
   async setAttribute(attr: String, value) {
     return this.callNative(RNPushdy.setAttribute, attr, value);
   }
@@ -402,7 +419,7 @@ class RNPushdyWrapper {
      */
     if (isAndroid) {
       // Read more about "enableFlag" at com.reactNativePushdy.PushdySdk#subscribedEventNames
-      this.subscribers["enableFlag"] = eventEmitter.addListener("enableFlag", (event) => {});
+      this.subscribers["enableFlag"] = eventEmitter.addListener("enableFlag", (event) => { });
       this.callNative(RNPushdy.setSubscribedEvents, keys);
     }
   }

--- a/index.js
+++ b/index.js
@@ -23,9 +23,9 @@ if (__DEV__) {
       console.log('%c' + fromTo + ' args, msg:', 'color: ' + color, msg.args, msg)
     }
   })
-  console.log('{PushdyMessaging} Spy enabled: ', );
+  console.log('{PushdyMessaging} Spy enabled: ',);
 } else {
-  console.log('{PushdyMessaging} Spy disabled: ', );
+  console.log('{PushdyMessaging} Spy disabled: ',);
 }
 
 const { RNPushdy } = NativeModules;
@@ -336,6 +336,23 @@ class RNPushdyWrapper {
     return items.map(i => new PushdyNotification(i));
   }
 
+  /**
+   * Flow here:
+   * When clicking notification from background or foreground. onNotificationOpened is triggered then
+   * notification is saved.
+   * getInitialNotification is used to re-trigger open notification when app restarts.
+   * If you handled initicalNotification successful, please call removeInitalNotification.
+   * @return JSONObject
+   */
+  async getInitialNotification() {
+    let a = await this.callNative(RNPushdy.getInitialNotification)
+    return a ? new PushdyNotification(a) : null;
+  }
+
+  async removeInitialNotification() {
+    return this.callNative(RNPushdy.removeInitialNotification);
+  }
+
   async setAttribute(attr: String, value) {
     return this.callNative(RNPushdy.setAttribute, attr, value);
   }
@@ -402,7 +419,7 @@ class RNPushdyWrapper {
      */
     if (isAndroid) {
       // Read more about "enableFlag" at com.reactNativePushdy.PushdySdk#subscribedEventNames
-      this.subscribers["enableFlag"] = eventEmitter.addListener("enableFlag", (event) => {});
+      this.subscribers["enableFlag"] = eventEmitter.addListener("enableFlag", (event) => { });
       this.callNative(RNPushdy.setSubscribedEvents, keys);
     }
   }

--- a/index.js
+++ b/index.js
@@ -345,8 +345,8 @@ class RNPushdyWrapper {
    * @return JSONObject
    */
   async getInitialNotification() {
-    let initialNotification = await this.callNative(RNPushdy.getInitialNotification)
-    return initialNotification;
+    let a = await this.callNative(RNPushdy.getInitialNotification)
+    return a ? new PushdyNotification(a) : null;
   }
 
   async removeInitialNotification() {

--- a/ios/RNPushdy+Data.swift
+++ b/ios/RNPushdy+Data.swift
@@ -31,7 +31,7 @@ public extension RNPushdy {
      
      - Parameters:
          - notification: The notification from PushdySDK
-     - Returns: Universal data structure
+     - Returns: Universal data structure/Users/mobiletech/rn3-24hmoney/node_modules/react-native-pushdy/RNPushdyStorage.swift
      */
     internal static func toRNPushdyStructure(_ notification:[String : Any]) -> [String : Any] {
         var universalNotification:[String : Any] = [:]
@@ -65,4 +65,22 @@ public extension RNPushdy {
         
         return universalNotification
     }
-}
+    
+    internal static func getLocalData(key: String) -> [String: Any]? {
+        if let value = UserDefaults.standard.object(forKey: key) {
+            return value;
+        }
+        return nil;
+    }
+    
+    internal static func setLocalData(key: String, value: [String: Any]) {
+        UserDefaults.standard.set(value, forKey: key);
+        UserDefaults.standard.synchronize()
+    }
+    
+    internal static func removeLocalData(key: String) {
+        if let _ = UserDefaults.standard.object(forKey: key) {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+ }

--- a/ios/RNPushdy+Data.swift
+++ b/ios/RNPushdy+Data.swift
@@ -68,7 +68,7 @@ public extension RNPushdy {
     
     internal static func getLocalData(key: String) -> [String: Any]? {
         if let value = UserDefaults.standard.object(forKey: key) {
-            return value;
+            return value as! [String : Any];
         }
         return nil;
     }

--- a/ios/RNPushdy+Data.swift
+++ b/ios/RNPushdy+Data.swift
@@ -31,7 +31,7 @@ public extension RNPushdy {
      
      - Parameters:
          - notification: The notification from PushdySDK
-     - Returns: Universal data structure/Users/mobiletech/rn3-24hmoney/node_modules/react-native-pushdy/RNPushdyStorage.swift
+     - Returns: Universal data structure
      */
     internal static func toRNPushdyStructure(_ notification:[String : Any]) -> [String : Any] {
         var universalNotification:[String : Any] = [:]

--- a/ios/RNPushdy+Data.swift
+++ b/ios/RNPushdy+Data.swift
@@ -65,4 +65,22 @@ public extension RNPushdy {
         
         return universalNotification
     }
-}
+    
+    internal static func getLocalData(key: String) -> [String: Any]? {
+        if let value = UserDefaults.standard.object(forKey: key) {
+            return value as! [String : Any];
+        }
+        return nil;
+    }
+    
+    internal static func setLocalData(key: String, value: [String: Any]) {
+        UserDefaults.standard.set(value, forKey: key);
+        UserDefaults.standard.synchronize()
+    }
+    
+    internal static func removeLocalData(key: String) {
+        if let _ = UserDefaults.standard.object(forKey: key) {
+            UserDefaults.standard.removeObject(forKey: key)
+        }
+    }
+ }

--- a/ios/RNPushdy.m
+++ b/ios/RNPushdy.m
@@ -113,6 +113,15 @@ RCT_EXTERN_METHOD(
                   rejecter: (RCTPromiseRejectBlock)reject
                   )
 
+RCT_EXTERN_METHOD(
+                  getInitialNotification: (RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject
+                  )
+
+RCT_EXTERN_METHOD(
+                  removeInitialNotification: (RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject
+                  )
 
 RCT_EXTERN_METHOD(
                   pushAttribute: (NSString *)attr

--- a/ios/RNPushdy.swift
+++ b/ios/RNPushdy.swift
@@ -279,6 +279,26 @@ public class RNPushdy: RCTEventEmitter {
     }
     
     @objc
+    func getInitialNotification(_
+        resolve: RCTPromiseResolveBlock, rejecter reject:RCTPromiseRejectBlock
+        ) -> Void {
+        let initialNotification:[String: Any]? = RNPushdy.getLocalData(key: "initialNotification");
+        if initialNotification != nil {
+            let universalNotification = RNPushdy.toRNPushdyStructure(initialNotification ?? [:]);
+            resolve(universalNotification)
+        } else {
+            resolve(nil);
+        }
+    }
+    
+    @objc
+    func removeInitialNotification(_
+        resolve: RCTPromiseResolveBlock, rejecter reject:RCTPromiseRejectBlock
+        ) -> Void {
+        RNPushdy.removeLocalData(key: "initialNotification");
+    }
+    
+    @objc
     func setAttribute(_
         attr: String, value: String,
                       resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock

--- a/ios/RNPushdyDelegate.swift
+++ b/ios/RNPushdyDelegate.swift
@@ -23,7 +23,7 @@ import PushdySDK
     
    public func onNotificationOpened(_ notification: [String : Any], fromState: String) {
        print("{RNPushdy.onNotificationOpened} from state: \(fromState)")
-       RNPushdy.setLocalData(key: "initialNotification", value: notification.description);
+       RNPushdy.setLocalData(key: "initialNotification", value: notification);
        let universalNotification = RNPushdy.toRNPushdyStructure(notification)
        sendEventToJs(eventName: "onNotificationOpened", body:["notification": universalNotification, "fromState": fromState])
    }

--- a/ios/RNPushdyDelegate.swift
+++ b/ios/RNPushdyDelegate.swift
@@ -8,8 +8,9 @@
 
 import Foundation
 import PushdySDK
-import React
-import React.RCTEventEmitter
+
+// import React
+// import React.RCTEventEmitter
 
 /**
  This class was intend to send event from RNPushdy to JS thread on PushdySDK events triggered
@@ -22,7 +23,7 @@ import React.RCTEventEmitter
     
    public func onNotificationOpened(_ notification: [String : Any], fromState: String) {
        print("{RNPushdy.onNotificationOpened} from state: \(fromState)")
-
+       RNPushdy.setLocalData(key: "initialNotification", value: notification);
        let universalNotification = RNPushdy.toRNPushdyStructure(notification)
        sendEventToJs(eventName: "onNotificationOpened", body:["notification": universalNotification, "fromState": fromState])
    }

--- a/ios/RNPushdyDelegate.swift
+++ b/ios/RNPushdyDelegate.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import PushdySDK
+
 // import React
 // import React.RCTEventEmitter
 
@@ -22,7 +23,7 @@ import PushdySDK
     
    public func onNotificationOpened(_ notification: [String : Any], fromState: String) {
        print("{RNPushdy.onNotificationOpened} from state: \(fromState)")
-
+       RNPushdy.setLocalData(key: "initialNotification", value: notification.description);
        let universalNotification = RNPushdy.toRNPushdyStructure(notification)
        sendEventToJs(eventName: "onNotificationOpened", body:["notification": universalNotification, "fromState": fromState])
    }

--- a/react-native-pushdy.podspec
+++ b/react-native-pushdy.podspec
@@ -19,8 +19,7 @@ Pod::Spec.new do |s|
   # Force support Swift version
   s.swift_versions = ['4.2', '5.0']
 
-  # TODO: Update this source
-  s.source       = { :git => "https://github.com/Pushdy/react-native-pushdy.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/Pushdy/react-native-pushdy.git"}
   # Temperary install from local
   # s.source       = { :http => 'file:' + __dir__ + '/Archive.zip'}
 


### PR DESCRIPTION
- add function getInitialNotification to re-trigger notification user had clicked before app restarted (by code flow, OS restart flow).
- add function removeInitialNotification to delete initial notification when it handled
- supported android + ios  and tested 