### PR TITLE
[feature] check app opened from push or not.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ React Native SDK for [Pushdy](https://guide.pushdy.com/i/) services
   - [pushAttribute(attr: String, value, commitImmediately: boolean)](#pushattributeattr-string-value-commitimmediately-boolean)
   - [getPlayerID()](#getplayerid)
   - [methodFoo(...args)](#methodfooargs)
+  - [isAppOpenedFromPush()](#isAppOpenedFromPush)
 - [Events References](#events-references)
   - [onTokenUpdated](#ontokenupdated)
   - [onNotificationOpened](#onnotificationopened)
@@ -762,6 +763,24 @@ Pushdy.startSubscribers({
   onRemoteNotificationRegistered: (event) => {},
   onTokenUpdated: ({ deviceToken }) => {},
 });
+```
+##### isAppOpenedFromPush()
+Desc:
+> This method will return isAppOpenedFromPush = true if app opened from push (when app was killed). 
+> When app enters background (when opened from push) isAppOpenedFromPush will reset it's value (isAppOpenedFromPush = false).
+> When app in background, then open push behavior will be different between each Platform (This method works in Android, currently not available in iOS)
+
+Usage:
+```
+// When app starts:
+let isAppOpenedFromPush = await Pushdy.isAppOpenedFromPush();
+if (isAppOpenedFromPush) {
+  // app opened from push
+} else {
+  // app opened by touch logo.
+}
+
+// When app opened from backgrounds : NOT WORKS IN IOS
 ```
 
 ##### methodFoo(...args)

--- a/android/src/main/java/com/reactNativePushdy/PushdyModule.java
+++ b/android/src/main/java/com/reactNativePushdy/PushdyModule.java
@@ -81,6 +81,11 @@ public class PushdyModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public  void isAppOpenedFromPush(Promise promise) {
+        promise.resolve(pushdySdk.isAppOpenedFromPush());
+    }
+
+    @ReactMethod
     public void isNotificationEnabled(Promise promise) {
         promise.resolve(pushdySdk.isNotificationEnabled());
     }

--- a/android/src/main/java/com/reactNativePushdy/PushdySdk.java
+++ b/android/src/main/java/com/reactNativePushdy/PushdySdk.java
@@ -139,9 +139,8 @@ public class PushdySdk implements Pushdy.PushdyDelegate, Application.ActivityLif
       // Log.d("RNPushdy", "this.subscribedEventNames.size() = " + this.subscribedEventNames.size());
 //       Log.d("RNPushdy", "jsThreadState = " + jsThreadState);
 //       Log.d("RNPushdy", "reactActivated = " + Boolean.toString(reactActivated));
-       Log.d("RNPushdy", "jsHandlerReady = " + Integer.toString(this.subscribedEventNames.size()));
+       Log.d("RNPushdy", "aaabbb = " + Integer.toString(this.subscribedEventNames.size()));
        Log.d("RNPushdy", "subscribedEventNames = " + this.subscribedEventNames.toString());
-
       if (reactActivated && jsThreadState == LifecycleState.RESUMED) {
         if (jsHandlerReady) {
           // Delay for some second to ensure react context work
@@ -293,7 +292,6 @@ public class PushdySdk implements Pushdy.PushdyDelegate, Application.ActivityLif
   @Override
   public void onNotificationOpened(@NotNull String notification, @NotNull String fromState) {
     Log.d("RNPushdy", "onNotificationOpened: notification: " + notification);
-
     WritableMap noti = new WritableNativeMap();
     try {
       JSONObject jo = new JSONObject(notification);
@@ -528,7 +526,7 @@ public class PushdySdk implements Pushdy.PushdyDelegate, Application.ActivityLif
 
   @Override
   public void onActivityStarted(@NonNull Activity activity) {
-    // Log.d("RNPushdy","onActivityStarted");
+    Log.d("RNPushdy","onActivityStarted");
   }
 
   @Override
@@ -538,7 +536,7 @@ public class PushdySdk implements Pushdy.PushdyDelegate, Application.ActivityLif
 
   @Override
   public void onActivityPaused(@NonNull Activity activity) {
-    // Log.d("RNPushdy","onActivityPaused");
+    Log.d("RNPushdy","onActivityPaused");
     if (this.mIsAppOpenedFromPush) {
       this.mIsAppOpenedFromPush = false;
     }

--- a/android/src/main/java/com/reactNativePushdy/PushdySdk.java
+++ b/android/src/main/java/com/reactNativePushdy/PushdySdk.java
@@ -1,8 +1,16 @@
 package com.reactNativePushdy;
 
+import android.app.Activity;
+import android.app.Application;
 import android.app.Notification;
+import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleObserver;
+import androidx.lifecycle.OnLifecycleEvent;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableArray;
@@ -29,7 +37,7 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.Arguments;
 
 
-public class PushdySdk implements Pushdy.PushdyDelegate {
+public class PushdySdk implements Pushdy.PushdyDelegate, Application.ActivityLifecycleCallbacks {
   private static PushdySdk instance = null;
   private ReactApplicationContext reactContext = null;
 
@@ -55,6 +63,11 @@ public class PushdySdk implements Pushdy.PushdyDelegate {
    */
   private Set<String> subscribedEventNames = new HashSet<>();
 
+  /**
+   * This should return true when app open from push when in background or when app was killed
+   */
+  private  boolean mIsAppOpenedFromPush = false;
+
   public static PushdySdk getInstance() {
     if (instance == null) instance = new PushdySdk();
 
@@ -79,6 +92,8 @@ public class PushdySdk implements Pushdy.PushdyDelegate {
     }
     Pushdy.registerForRemoteNotification();
     Pushdy.setBadgeOnForeground(true);
+    Application mMainAppContext = (Application) mainAppContext;
+    mMainAppContext.registerActivityLifecycleCallbacks(instance);
   }
 
   public void initPushdy(ReadableMap options) throws Exception {
@@ -296,6 +311,7 @@ public class PushdySdk implements Pushdy.PushdyDelegate {
     params.putMap("notification", RNPushdyData.toRNPushdyStructure(noti));
 
     sendEvent("onNotificationOpened", params);
+    this.mIsAppOpenedFromPush = true;
   }
 
   /**
@@ -495,5 +511,51 @@ public class PushdySdk implements Pushdy.PushdyDelegate {
 
   public void setSubscribedEvents(ArrayList<String> subscribedEventNames) {
     this.subscribedEventNames = new HashSet<String>(subscribedEventNames);
+  }
+
+  /**
+   * Return is app open from push or not
+   * @return boolean
+   */
+  public boolean isAppOpenedFromPush() {
+    return this.mIsAppOpenedFromPush;
+  }
+
+  @Override
+  public void onActivityCreated(@NonNull Activity activity, @androidx.annotation.Nullable Bundle savedInstanceState) {
+
+  }
+
+  @Override
+  public void onActivityStarted(@NonNull Activity activity) {
+    // Log.d("RNPushdy","onActivityStarted");
+  }
+
+  @Override
+  public void onActivityResumed(@NonNull Activity activity) {
+
+  }
+
+  @Override
+  public void onActivityPaused(@NonNull Activity activity) {
+    // Log.d("RNPushdy","onActivityPaused");
+    if (this.mIsAppOpenedFromPush) {
+      this.mIsAppOpenedFromPush = false;
+    }
+  }
+
+  @Override
+  public void onActivityStopped(@NonNull Activity activity) {
+
+  }
+
+  @Override
+  public void onActivitySaveInstanceState(@NonNull Activity activity, @NonNull Bundle outState) {
+
+  }
+
+  @Override
+  public void onActivityDestroyed(@NonNull Activity activity) {
+
   }
 }

--- a/android/src/main/java/com/reactNativePushdy/PushdySdk.java
+++ b/android/src/main/java/com/reactNativePushdy/PushdySdk.java
@@ -139,8 +139,9 @@ public class PushdySdk implements Pushdy.PushdyDelegate, Application.ActivityLif
       // Log.d("RNPushdy", "this.subscribedEventNames.size() = " + this.subscribedEventNames.size());
 //       Log.d("RNPushdy", "jsThreadState = " + jsThreadState);
 //       Log.d("RNPushdy", "reactActivated = " + Boolean.toString(reactActivated));
-       Log.d("RNPushdy", "aaabbb = " + Integer.toString(this.subscribedEventNames.size()));
+       Log.d("RNPushdy", "jsHandlerReady = " + Integer.toString(this.subscribedEventNames.size()));
        Log.d("RNPushdy", "subscribedEventNames = " + this.subscribedEventNames.toString());
+
       if (reactActivated && jsThreadState == LifecycleState.RESUMED) {
         if (jsHandlerReady) {
           // Delay for some second to ensure react context work

--- a/index.js
+++ b/index.js
@@ -399,6 +399,10 @@ class RNPushdyWrapper {
     return this.callNative(RNPushdy.getPlayerID);
   }
 
+  async makeCrash() {
+    return this.callNative(RNPushdy.makeCrash);
+  }
+
   /**
    * ========= Hooks ============
    */

--- a/index.js
+++ b/index.js
@@ -356,6 +356,10 @@ class RNPushdyWrapper {
     return this.callNative(RNPushdy.removeInitialNotification);
   }
 
+  async isAppOpenedFromPush() {
+    return this.callNative(RNPushdy.isAppOpenedFromPush);
+  }
+
   async setAttribute(attr: String, value, immediately = false) {
     if (value === null || value === undefined) {
       console.warn("[Pushdy] ERROR: Invalid value argument, must not null/undefined instead of: ", value);
@@ -386,10 +390,6 @@ class RNPushdyWrapper {
 
   async getPlayerID() {
     return this.callNative(RNPushdy.getPlayerID);
-  }
-
-  async makeCrash() {
-    return this.callNative(RNPushdy.makeCrash);
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -356,6 +356,13 @@ class RNPushdyWrapper {
     return this.callNative(RNPushdy.removeInitialNotification);
   }
 
+  /**
+   * This method will return isAppOpenedFromPush = true if app opened from push (when app was killed). 
+   * 
+   * When app enters background (when opened from push) isAppOpenedFromPush will reset it's value (isAppOpenedFromPush = false).
+   * 
+   * When app in background, then open push behavior will be different between each Platform (This method works in Android, currently not available in iOS)
+   */
   async isAppOpenedFromPush() {
     return this.callNative(RNPushdy.isAppOpenedFromPush);
   }

--- a/ios/RNPushdy.m
+++ b/ios/RNPushdy.m
@@ -149,6 +149,10 @@ RCT_EXTERN_METHOD(
                   getPlayerID: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject
                   )
+RCT_EXTERN_METHOD(
+                  isAppOpenedFromPush: (RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject
+                  )
 
 /**
  Swift: Calling Swift functions from Objective-C

--- a/ios/RNPushdy.swift
+++ b/ios/RNPushdy.swift
@@ -99,6 +99,12 @@ public class RNPushdy: RCTEventEmitter {
         self.delegate = delegate
         self.launchOptions = launchOptions
         self.mIsAppOpenedFromPush = self.checkIsAppOpenedFromPush(_launchOptions: launchOptions);
+        
+        if #available(iOS 13.0, *){
+            NotificationCenter.default.addObserver(self, selector: #selector(self.appEntersBackground), name: UIScene.willDeactivateNotification, object: nil);
+        } else {
+            NotificationCenter.default.addObserver(self, selector: #selector(self.appEntersBackground), name: UIApplication.willResignActiveNotification, object: nil);
+        }
     }
     
     @objc
@@ -108,6 +114,11 @@ public class RNPushdy: RCTEventEmitter {
         } else {
             return false;
         }
+    }
+    
+    @objc
+    public static func appEntersBackground() {
+        RNPushdy.self.mIsAppOpenedFromPush = false;
     }
     
     @objc

--- a/ios/RNPushdy.swift
+++ b/ios/RNPushdy.swift
@@ -18,6 +18,7 @@ public class RNPushdy: RCTEventEmitter {
     @objc private static var clientKey:String? = nil
     @objc private static var delegate:UIApplicationDelegate? = nil
     @objc private static var launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    @objc private static var mIsAppOpenedFromPush: Bool = false
     
     override init() {
         super.init()
@@ -97,6 +98,16 @@ public class RNPushdy: RCTEventEmitter {
         self.clientKey = clientKey
         self.delegate = delegate
         self.launchOptions = launchOptions
+        self.mIsAppOpenedFromPush = self.checkIsAppOpenedFromPush(_launchOptions: launchOptions);
+    }
+    
+    @objc
+    public static func checkIsAppOpenedFromPush(_launchOptions:[UIApplication.LaunchOptionsKey: Any]?) ->Bool {
+        if let launchOptions = _launchOptions, let notification = launchOptions[UIApplication.LaunchOptionsKey.remoteNotification] as? [String : Any] {
+            return true;
+        } else {
+            return false;
+        }
     }
     
     @objc
@@ -296,6 +307,13 @@ public class RNPushdy: RCTEventEmitter {
         resolve: RCTPromiseResolveBlock, rejecter reject:RCTPromiseRejectBlock
         ) -> Void {
         RNPushdy.removeLocalData(key: "initialNotification");
+    }
+    
+    @objc
+    func isAppOpenedFromPush(_
+        resolve: RCTPromiseResolveBlock, rejecter
+        reject:RCTPromiseRejectBlock) -> Void {
+        resolve(RNPushdy.self.mIsAppOpenedFromPush);
     }
     
     


### PR DESCRIPTION
Check the app open from push when the application starts faster (currently waste 100ms in DEV mode. (delay from native sendEvent to JS)). If it's opened from a notification, it will make the application wait in SplashPage and redirect to the screen you want when receiving the event open push later.  
It's native behavior when opening notification.