### PR TITLE
fix(badge): convert NSNumber to Int

### DIFF
--- a/ios/RNPushdy.swift
+++ b/ios/RNPushdy.swift
@@ -419,10 +419,14 @@ public class RNPushdy: RCTEventEmitter {
     }
     
     @objc func setApplicationIconBadgeNumber(_
-        count: Int,
+        count: NSNumber,
         resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock
     ) -> Void {
-        Pushdy.setApplicationIconBadgeNumber(count)
+        // Pushdy.setApplicationIconBadgeNumber using count Int;
+        // And setApplicationIconBadgeNumber call from ReactNative is NSNumber type.
+        // So that need to convert NSNumber to Int.
+        let countInt = count.intValue;
+        Pushdy.setApplicationIconBadgeNumber(countInt)
         resolve(true)
     }
 


### PR DESCRIPTION
Vì hàm Pushdy.setApplicationIconBadgeNumber cần sử dụng kiểu dữ liệu Integer nhưng hàm setApplicationIconBadgeNumber gọi từ phía ReactNative sẽ đẩy số dạng NSNumber nên cần có bước quy đổi NSNumber sang Int value trước khi gọi Pushdy.setApplicationIconBadgeNumber