### PR TITLE
feat(new-flow): new flow registerSdk to fix bug and bump to version 4.0

### DIFF
--- a/ios/RNPushdy+Data.swift
+++ b/ios/RNPushdy+Data.swift
@@ -68,7 +68,10 @@ public extension RNPushdy {
     
     internal static func getLocalData(key: String) -> [String: Any]? {
         if let value = UserDefaults.standard.object(forKey: key) {
-            return value as! [String : Any];
+            /**
+             repair error that need to getLocalData cannot return nil value even not set yet.
+             */
+            return value as? [String : Any];
         }
         return nil;
     }

--- a/ios/RNPushdy.swift
+++ b/ios/RNPushdy.swift
@@ -9,6 +9,11 @@ import Foundation
 import os
 import PushdySDK
 
+/**
+ *  RNPushdy should open register once and only one.
+ *  If registerSDK call twice, it will miss the next incoming background notification.
+ */
+var didInitialize: Bool = false;
 
 @objc(RNPushdy)
 public class RNPushdy: RCTEventEmitter {
@@ -95,6 +100,11 @@ public class RNPushdy: RCTEventEmitter {
 
     @objc
     public static func registerSdk(_ clientKey:String, delegate:UIApplicationDelegate, launchOptions: [UIApplication.LaunchOptionsKey: Any]?) {
+        if (didInitialize) {
+            return;
+        }
+
+        didInitialize = true;
         self.clientKey = clientKey
         self.delegate = delegate
         self.launchOptions = launchOptions
@@ -109,7 +119,7 @@ public class RNPushdy: RCTEventEmitter {
     
     @objc
     public static func checkIsAppOpenedFromPush(_launchOptions:[UIApplication.LaunchOptionsKey: Any]?) ->Bool {
-        if let launchOptions = _launchOptions, let notification = launchOptions[UIApplication.LaunchOptionsKey.remoteNotification] as? [String : Any] {
+        if let launchOptions = _launchOptions, let _ = launchOptions[UIApplication.LaunchOptionsKey.remoteNotification] as? [String : Any] {
             return true;
         } else {
             return false;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pushdy",
   "title": "React Native Pushdy",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Pushdy Sdk implement for React Native",
   "main": "index.js",
   "scripts": {

--- a/react-native-pushdy.podspec
+++ b/react-native-pushdy.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.dependency "React"
   # ...
   # s.dependency "..."
-  s.dependency 'PushdySDK', '0.3.1'
+  s.dependency 'PushdySDK', '0.4.0'
 end
 
 # post_install do |installer|


### PR DESCRIPTION
 -------- NEW FLOW --------
         If HAVE deviceId,
         1. try to initialize with PushdySDK without handler called by registerSdk (invoked by applicationDidFinishLauchingWithOptions.
         2. Add delegateHandler to PushdySDK later called by initPushdy(invoked by initPushdy when ReactNative App starts and ready to handle the message.
         If not,
         1. registerSdk normally. (without initializing with Pushdy)
         2. initPushdy when ReactNative App start and ready to handle the message.
         */